### PR TITLE
Changing the master and slave terminology

### DIFF
--- a/boto/emr/connection.py
+++ b/boto/emr/connection.py
@@ -189,8 +189,8 @@ class EmrConnection(AWSQueryConnection):
 		return self.get_object('ModifyInstanceGroups', params, ModifyInstanceGroupsResponse, verb='POST')
 
     def run_jobflow(self, name, log_uri, ec2_keyname=None, availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version='0.18',
@@ -207,10 +207,10 @@ class EmrConnection(AWSQueryConnection):
         :param ec2_keyname: EC2 key used for the instances
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
         :type action_on_failure: str
@@ -233,7 +233,7 @@ class EmrConnection(AWSQueryConnection):
 
         # Instance args
         instance_params = self._build_instance_args(ec2_keyname, availability_zone,
-                                                    master_instance_type, slave_instance_type,
+                                                    main_instance_type, subordinate_instance_type,
                                                     num_instances, keep_alive, hadoop_version)
         params.update(instance_params)
 
@@ -310,11 +310,11 @@ class EmrConnection(AWSQueryConnection):
                 params['Steps.member.%s.%s' % (i+1, key)] = value
         return params
 
-    def _build_instance_args(self, ec2_keyname, availability_zone, master_instance_type,
-                             slave_instance_type, num_instances, keep_alive, hadoop_version):
+    def _build_instance_args(self, ec2_keyname, availability_zone, main_instance_type,
+                             subordinate_instance_type, num_instances, keep_alive, hadoop_version):
         params = {
-            'Instances.MasterInstanceType' : master_instance_type,
-            'Instances.SlaveInstanceType' : slave_instance_type,
+            'Instances.MainInstanceType' : main_instance_type,
+            'Instances.SubordinateInstanceType' : subordinate_instance_type,
             'Instances.InstanceCount' : num_instances,
             'Instances.KeepJobFlowAliveWhenNoSteps' : str(keep_alive).lower(),
             'Instances.HadoopVersion' : hadoop_version

--- a/boto/emr/step.py
+++ b/boto/emr/step.py
@@ -122,7 +122,7 @@ class StreamingStep(Step):
         :type output: str
         :param output: The output uri
         :type jar: str
-        :param jar: The hadoop streaming jar. This can be either a local path on the master node, or an s3:// URI.
+        :param jar: The hadoop streaming jar. This can be either a local path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/boto/pyami/bootstrap.py
+++ b/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/boto/rds/__init__.py
+++ b/boto/rds/__init__.py
@@ -113,7 +113,7 @@ class RDSConnection(AWSQueryConnection):
         return self.get_list('DescribeDBInstances', params, [('DBInstance', DBInstance)])
 
     def create_dbinstance(self, id, allocated_storage, instance_class,
-                          master_username, master_password, port=3306,
+                          main_username, main_password, port=3306,
                           engine='MySQL5.1', db_name=None, param_group=None,
                           security_groups=None, availability_zone=None,
                           preferred_maintenance_window=None,
@@ -150,13 +150,13 @@ class RDSConnection(AWSQueryConnection):
         :type engine: str
         :param engine: Name of database engine. Must be MySQL5.1 for now.
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
                                 Must be 1-15 alphanumeric characters, first
                                 must be a letter.
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-16 alphanumeric characters.
 
         :type port: int
@@ -217,8 +217,8 @@ class RDSConnection(AWSQueryConnection):
                   'AllocatedStorage' : allocated_storage,
                   'DBInstanceClass' : instance_class,
                   'Engine' : engine,
-                  'MasterUsername' : master_username,
-                  'MasterUserPassword' : master_password}
+                  'MainUsername' : main_username,
+                  'MainUserPassword' : main_password}
         if port:
             params['Port'] = port
         if db_name:
@@ -321,7 +321,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -343,8 +343,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -402,8 +402,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'DBSecurityGroups.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/boto/rds/dbinstance.py
+++ b/boto/rds/dbinstance.py
@@ -36,7 +36,7 @@ class DBInstance(object):
         self.allocated_storage = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_group = None
         self.security_group = None
         self.availability_zone = None
@@ -82,8 +82,8 @@ class DBInstance(object):
             self.allocated_storage = int(value)
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -176,7 +176,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -195,8 +195,8 @@ class DBInstance(object):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -245,7 +245,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/boto/rds/dbsnapshot.py
+++ b/boto/rds/dbsnapshot.py
@@ -33,7 +33,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -61,8 +61,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/zinnia/tests/entry.py
+++ b/zinnia/tests/entry.py
@@ -47,8 +47,8 @@ class EntryTestCase(TestCase):
         self.assertEquals(self.entry.pingbacks.count(), 0)
         self.assertEquals(self.entry.trackbacks.count(), 0)
 
-        author = User.objects.create_user(username='webmaster',
-                                          email='webmaster@example.com')
+        author = User.objects.create_user(username='webmain',
+                                          email='webmain@example.com')
 
         comment = Comment.objects.create(comment='My Comment 3',
                                          content_object=self.entry,

--- a/zinnia/tests/managers.py
+++ b/zinnia/tests/managers.py
@@ -21,8 +21,8 @@ class ManagersTestCase(TestCase):
         self.sites = [Site.objects.get_current(),
                       Site.objects.create(domain='http://domain.com',
                                           name='Domain.com')]
-        self.authors = [User.objects.create_user(username='webmaster',
-                                                 email='webmaster@example.com'),
+        self.authors = [User.objects.create_user(username='webmain',
+                                                 email='webmain@example.com'),
                         User.objects.create_user(username='contributor',
                                                  email='contributor@example.com')]
         self.categories = [Category.objects.create(title='Category 1',
@@ -142,36 +142,36 @@ class ManagersTestCase(TestCase):
         self.assertEquals(Entry.published.advanced_search('content category:"category-2"').count(), 1)
         self.assertEquals(Entry.published.advanced_search('content tag:zinnia').count(), 2)
         self.assertEquals(Entry.published.advanced_search('content tag:custom').count(), 1)
-        self.assertEquals(Entry.published.advanced_search('content author:webmaster').count(), 2)
+        self.assertEquals(Entry.published.advanced_search('content author:webmain').count(), 2)
         self.assertEquals(Entry.published.advanced_search('content author:contributor').count(), 1)
-        self.assertEquals(Entry.published.advanced_search('content author:webmaster tag:zinnia').count(), 2)
-        self.assertEquals(Entry.published.advanced_search('content author:webmaster tag:custom').count(), 1)
-        self.assertEquals(Entry.published.advanced_search('content 1 or 2 author:webmaster').count(), 2)
-        self.assertEquals(Entry.published.advanced_search('content 1 or 2 author:webmaster').count(), 2)
-        self.assertEquals(Entry.published.advanced_search('(author:webmaster content) my').count(), 2)
-        self.assertEquals(Entry.published.advanced_search('(author:webmaster) or (author:contributor)').count(), 2)
-        self.assertEquals(Entry.published.advanced_search('(author:webmaster) (author:contributor)').count(), 0)
-        self.assertEquals(Entry.published.advanced_search('(author:webmaster content) 1').count(), 1)
-        self.assertEquals(Entry.published.advanced_search('(author:webmaster content) or 2').count(), 2)
+        self.assertEquals(Entry.published.advanced_search('content author:webmain tag:zinnia').count(), 2)
+        self.assertEquals(Entry.published.advanced_search('content author:webmain tag:custom').count(), 1)
+        self.assertEquals(Entry.published.advanced_search('content 1 or 2 author:webmain').count(), 2)
+        self.assertEquals(Entry.published.advanced_search('content 1 or 2 author:webmain').count(), 2)
+        self.assertEquals(Entry.published.advanced_search('(author:webmain content) my').count(), 2)
+        self.assertEquals(Entry.published.advanced_search('(author:webmain) or (author:contributor)').count(), 2)
+        self.assertEquals(Entry.published.advanced_search('(author:webmain) (author:contributor)').count(), 0)
+        self.assertEquals(Entry.published.advanced_search('(author:webmain content) 1').count(), 1)
+        self.assertEquals(Entry.published.advanced_search('(author:webmain content) or 2').count(), 2)
         self.assertEquals(Entry.published.advanced_search('(author:contributor content) or 1').count(), 2)
         self.assertEquals(Entry.published.advanced_search('(author:contributor content) or 2').count(), 1)
-        self.assertEquals(Entry.published.advanced_search('(author:webmaster or ("hello world")) and 2').count(), 1)
+        self.assertEquals(Entry.published.advanced_search('(author:webmain or ("hello world")) and 2').count(), 1)
 
         # Complex queries
-        self.assertEquals(Entry.published.advanced_search('(author:admin and "content 1") or author:webmaster').count(), 2)
-        self.assertEquals(Entry.published.advanced_search('author:admin and ("content 1" or author:webmaster)').count(), 0)
-        self.assertEquals(Entry.published.advanced_search('author:admin and "content 1" or author:webmaster').count(), 0)
-        self.assertEquals(Entry.published.advanced_search('-(author:webmaster and "content 1")').count(), 1)
-        self.assertEquals(Entry.published.advanced_search('-(-author:webmaster and "content 1")').count(), 2)
-        self.assertEquals(Entry.published.advanced_search('category:"category -1" or author:"web master"').count(), 0)
-        self.assertEquals(Entry.published.advanced_search('category:"category-1" or author:"webmaster"').count(), 2)
+        self.assertEquals(Entry.published.advanced_search('(author:admin and "content 1") or author:webmain').count(), 2)
+        self.assertEquals(Entry.published.advanced_search('author:admin and ("content 1" or author:webmain)').count(), 0)
+        self.assertEquals(Entry.published.advanced_search('author:admin and "content 1" or author:webmain').count(), 0)
+        self.assertEquals(Entry.published.advanced_search('-(author:webmain and "content 1")').count(), 1)
+        self.assertEquals(Entry.published.advanced_search('-(-author:webmain and "content 1")').count(), 2)
+        self.assertEquals(Entry.published.advanced_search('category:"category -1" or author:"web main"').count(), 0)
+        self.assertEquals(Entry.published.advanced_search('category:"category-1" or author:"webmain"').count(), 2)
 
         # Wildcards
         self.assertEquals(Entry.published.advanced_search('author:webm*').count(), 2)
         self.assertEquals(Entry.published.advanced_search('author:*bmas*').count(), 2)
-        self.assertEquals(Entry.published.advanced_search('author:*master').count(), 2)
-        self.assertEquals(Entry.published.advanced_search('author:*master category:*ory-2').count(), 1)
-        self.assertEquals(Entry.published.advanced_search('author:*master or category:cate*').count(), 2)
+        self.assertEquals(Entry.published.advanced_search('author:*main').count(), 2)
+        self.assertEquals(Entry.published.advanced_search('author:*main category:*ory-2').count(), 1)
+        self.assertEquals(Entry.published.advanced_search('author:*main or category:cate*').count(), 2)
         self.assertEquals(Entry.published.advanced_search('category:*ate*').count(), 2)
         self.assertEquals(Entry.published.advanced_search('author:"webmast*"').count(), 0)
         self.assertEquals(Entry.published.advanced_search('tag:"zinnia*"').count(), 0)

--- a/zinnia/tests/metaweblog.py
+++ b/zinnia/tests/metaweblog.py
@@ -26,8 +26,8 @@ class MetaWeblogTestCase(TestCase):
 
     def setUp(self):
         # Create data
-        self.webmaster = User.objects.create_superuser(username='webmaster',
-                                                       email='webmaster@example.com',
+        self.webmain = User.objects.create_superuser(username='webmain',
+                                                       email='webmain@example.com',
                                                        password='password')
         self.contributor = User.objects.create_user(username='contributor',
                                                     email='contributor@example.com',
@@ -42,7 +42,7 @@ class MetaWeblogTestCase(TestCase):
                   'creation_date': datetime(2010, 1, 1),
                   'status': PUBLISHED}
         self.entry_1 = Entry.objects.create(**params)
-        self.entry_1.authors.add(self.webmaster)
+        self.entry_1.authors.add(self.webmain)
         self.entry_1.categories.add(*self.categories)
         self.entry_1.sites.add(self.site)
 
@@ -50,7 +50,7 @@ class MetaWeblogTestCase(TestCase):
                   'creation_date': datetime(2010, 3, 15),
                   'tags': 'zinnia, test', 'slug': 'my-entry-2'}
         self.entry_2 = Entry.objects.create(**params)
-        self.entry_2.authors.add(self.webmaster)
+        self.entry_2.authors.add(self.webmain)
         self.entry_2.categories.add(self.categories[0])
         self.entry_2.sites.add(self.site)
         # Instanciating the server proxy
@@ -65,15 +65,15 @@ class MetaWeblogTestCase(TestCase):
         self.contributor.save()
         self.assertEquals(authenticate('contributor', 'password'), self.contributor)
         self.assertRaises(Fault, authenticate, 'contributor', 'password', 'zinnia.change_entry')
-        self.assertEquals(authenticate('webmaster', 'password'), self.webmaster)
-        self.assertEquals(authenticate('webmaster', 'password', 'zinnia.change_entry'),
-                          self.webmaster)
+        self.assertEquals(authenticate('webmain', 'password'), self.webmain)
+        self.assertEquals(authenticate('webmain', 'password', 'zinnia.change_entry'),
+                          self.webmain)
 
     def test_get_users_blogs(self):
         self.assertRaises(Fault, self.server.blogger.getUsersBlogs,
                           'apikey', 'contributor', 'password')
         self.assertEquals(self.server.blogger.getUsersBlogs(
-            'apikey', 'webmaster', 'password'),
+            'apikey', 'webmain', 'password'),
                           [{'url': 'http://example.com/',
                             'blogid': 1,
                             'blogName': 'example.com'}])
@@ -81,30 +81,30 @@ class MetaWeblogTestCase(TestCase):
     def test_get_user_info(self):
         self.assertRaises(Fault, self.server.blogger.getUserInfo,
                           'apikey', 'contributor', 'password')
-        self.webmaster.first_name = 'John'
-        self.webmaster.last_name = 'Doe'
-        self.webmaster.save()
+        self.webmain.first_name = 'John'
+        self.webmain.last_name = 'Doe'
+        self.webmain.save()
         self.assertEquals(self.server.blogger.getUserInfo(
-            'apikey', 'webmaster', 'password'),
+            'apikey', 'webmain', 'password'),
                           {'firstname': 'John', 'lastname': 'Doe',
                            'url': 'http://example.com/authors/webmaster/',
-                           'userid': self.webmaster.pk, 'nickname': 'webmaster',
-                           'email': 'webmaster@example.com'})
+                           'userid': self.webmain.pk, 'nickname': 'webmain',
+                           'email': 'webmain@example.com'})
 
     def test_get_authors(self):
         self.assertRaises(Fault, self.server.wp.getAuthors,
                           'apikey', 'contributor', 'password')
         self.assertEquals(self.server.wp.getAuthors(
-            'apikey', 'webmaster', 'password'), [
-                              {'user_login': 'webmaster', 'user_id': self.webmaster.pk,
-                               'user_email': 'webmaster@example.com',
-                               'display_name': 'webmaster'}])
+            'apikey', 'webmain', 'password'), [
+                              {'user_login': 'webmain', 'user_id': self.webmain.pk,
+                               'user_email': 'webmain@example.com',
+                               'display_name': 'webmain'}])
 
     def test_get_categories(self):
         self.assertRaises(Fault, self.server.metaWeblog.getCategories,
                           1, 'contributor', 'password')
         self.assertEquals(self.server.metaWeblog.getCategories(
-            'apikey', 'webmaster', 'password'),
+            'apikey', 'webmain', 'password'),
                           [{'rssUrl': 'http://example.com/feeds/categories/category-1/',
                             'description': 'Category 1',
                             'htmlUrl': 'http://example.com/categories/category-1/',
@@ -121,7 +121,7 @@ class MetaWeblogTestCase(TestCase):
         self.categories[1].description = 'category 2 description'
         self.categories[1].save()
         self.assertEquals(self.server.metaWeblog.getCategories(
-            'apikey', 'webmaster', 'password'),
+            'apikey', 'webmain', 'password'),
                           [{'rssUrl': 'http://example.com/feeds/categories/category-1/',
                             'description': 'Category 1',
                             'htmlUrl': 'http://example.com/categories/category-1/',
@@ -143,7 +143,7 @@ class MetaWeblogTestCase(TestCase):
                           1, 'contributor', 'password', category_struct)
         self.assertEquals(Category.objects.count(), 2)
         new_category_id = self.server.wp.newCategory(
-            1, 'webmaster', 'password', category_struct)
+            1, 'webmain', 'password', category_struct)
         self.assertEquals(Category.objects.count(), 3)
         category = Category.objects.get(pk=new_category_id)
         self.assertEquals(category.title, 'Category 3')
@@ -155,21 +155,21 @@ class MetaWeblogTestCase(TestCase):
         self.assertRaises(Fault, self.server.metaWeblog.getRecentPosts,
                           1, 'contributor', 'password', 10)
         self.assertEquals(len(self.server.metaWeblog.getRecentPosts(
-            1, 'webmaster', 'password', 10)), 2)
+            1, 'webmain', 'password', 10)), 2)
 
     def test_delete_post(self):
         self.assertRaises(Fault, self.server.blogger.deletePost,
                           'apikey', 1, 'contributor', 'password', 'publish')
         self.assertEquals(Entry.objects.count(), 2)
         self.assertEquals(self.server.blogger.deletePost(
-            'apikey', self.entry_1.pk, 'webmaster', 'password', 'publish'), True)
+            'apikey', self.entry_1.pk, 'webmain', 'password', 'publish'), True)
         self.assertEquals(Entry.objects.count(), 1)
 
     def test_get_post(self):
         self.assertRaises(Fault, self.server.metaWeblog.getPost,
                           1, 'contributor', 'password')
         post = self.server.metaWeblog.getPost(
-            self.entry_1.pk, 'webmaster', 'password')
+            self.entry_1.pk, 'webmain', 'password')
         self.assertEquals(post['title'], self.entry_1.title)
         self.assertEquals(post['description'], '<p>My content 1</p>')
         self.assertEquals(post['categories'], ['Category 1', 'Category 2'])
@@ -177,14 +177,14 @@ class MetaWeblogTestCase(TestCase):
         self.assertEquals(post['link'], 'http://example.com/2010/01/01/my-entry-1/')
         self.assertEquals(post['permaLink'], 'http://example.com/2010/01/01/my-entry-1/')
         self.assertEquals(post['postid'], self.entry_1.pk)
-        self.assertEquals(post['userid'], 'webmaster')
+        self.assertEquals(post['userid'], 'webmain')
         self.assertEquals(post['mt_excerpt'], '')
         self.assertEquals(post['mt_allow_comments'], 1)
         self.assertEquals(post['mt_allow_pings'], 1)
         self.assertEquals(post['mt_keywords'], self.entry_1.tags)
-        self.assertEquals(post['wp_author'], 'webmaster')
-        self.assertEquals(post['wp_author_id'], self.webmaster.pk)
-        self.assertEquals(post['wp_author_display_name'], 'webmaster')
+        self.assertEquals(post['wp_author'], 'webmain')
+        self.assertEquals(post['wp_author_id'], self.webmain.pk)
+        self.assertEquals(post['wp_author_display_name'], 'webmain')
         self.assertEquals(post['wp_password'], '')
         self.assertEquals(post['wp_slug'], self.entry_1.slug)
 
@@ -195,13 +195,13 @@ class MetaWeblogTestCase(TestCase):
         self.assertEquals(Entry.objects.count(), 2)
         self.assertEquals(Entry.published.count(), 1)
         self.server.metaWeblog.newPost(
-            1, 'webmaster', 'password', post, 1)
+            1, 'webmain', 'password', post, 1)
         self.assertEquals(Entry.objects.count(), 3)
         self.assertEquals(Entry.published.count(), 2)
         del post['dateCreated']
         post['wp_author_id'] = self.contributor.pk
         self.server.metaWeblog.newPost(
-            1, 'webmaster', 'password', post, 0)
+            1, 'webmain', 'password', post, 0)
         self.assertEquals(Entry.objects.count(), 4)
         self.assertEquals(Entry.published.count(), 2)
 
@@ -210,7 +210,7 @@ class MetaWeblogTestCase(TestCase):
         self.assertRaises(Fault, self.server.metaWeblog.editPost,
                           1, 'contributor', 'password', post, 1)
         new_post_id = self.server.metaWeblog.newPost(
-            1, 'webmaster', 'password', post, 0)
+            1, 'webmain', 'password', post, 0)
 
         entry = Entry.objects.get(pk=new_post_id)
         self.assertEquals(entry.title, self.entry_2.title)
@@ -223,7 +223,7 @@ class MetaWeblogTestCase(TestCase):
         self.assertEquals(entry.pingback_enabled, True)
         self.assertEquals(entry.categories.count(), 1)
         self.assertEquals(entry.authors.count(), 1)
-        self.assertEquals(entry.authors.all()[0], self.webmaster)
+        self.assertEquals(entry.authors.all()[0], self.webmain)
         self.assertEquals(entry.creation_date, self.entry_2.creation_date)
 
         entry.title = 'Title edited'
@@ -238,7 +238,7 @@ class MetaWeblogTestCase(TestCase):
         post['mt_allow_pings'] = 0
 
         response = self.server.metaWeblog.editPost(
-            new_post_id, 'webmaster', 'password', post, 1)
+            new_post_id, 'webmain', 'password', post, 1)
         self.assertEquals(response, True)
         entry = Entry.objects.get(pk=new_post_id)
         self.assertEquals(entry.title, post['title'])
@@ -256,7 +256,7 @@ class MetaWeblogTestCase(TestCase):
         post['wp_author_id'] = self.contributor.pk
 
         response = self.server.metaWeblog.editPost(
-            new_post_id, 'webmaster', 'password', post, 1)
+            new_post_id, 'webmain', 'password', post, 1)
         entry = Entry.objects.get(pk=new_post_id)
         self.assertEquals(entry.authors.count(), 1)
         self.assertEquals(entry.authors.all()[0], self.contributor)
@@ -274,6 +274,6 @@ class MetaWeblogTestCase(TestCase):
         self.assertRaises(Fault, self.server.metaWeblog.newMediaObject,
                           1, 'contributor', 'password', media)
         new_media = self.server.metaWeblog.newMediaObject(
-            1, 'webmaster', 'password', media)
+            1, 'webmain', 'password', media)
         self.assertTrue('/zinnia_test_file' in new_media['url'])
         default_storage.delete('/'.join([UPLOAD_TO, new_media['url'].split('/')[-1]]))

--- a/zinnia/tests/pingback.py
+++ b/zinnia/tests/pingback.py
@@ -45,8 +45,8 @@ class PingBackTestCase(TestCase):
         self.site.domain = 'localhost:8000'
         self.site.save()
         # Creating tests entries
-        self.author = User.objects.create_user(username='webmaster',
-                                               email='webmaster@example.com')
+        self.author = User.objects.create_user(username='webmain',
+                                               email='webmain@example.com')
         self.category = Category.objects.create(title='test', slug='test')
         params = {'title': 'My first entry',
                   'content': 'My first content',

--- a/zinnia/tests/templatetags.py
+++ b/zinnia/tests/templatetags.py
@@ -63,8 +63,8 @@ class TemplateTagsTestCase(TestCase):
         self.assertEquals(len(context['authors']), 0)
         self.assertEquals(context['template'], 'zinnia/tags/authors.html')
 
-        user = User.objects.create_user(username='webmaster',
-                                        email='webmaster@example.com')
+        user = User.objects.create_user(username='webmain',
+                                        email='webmain@example.com')
         self.entry.authors.add(user)
         self.publish_entry()
         context = get_authors('custom_template.html')
@@ -272,8 +272,8 @@ class TemplateTagsTestCase(TestCase):
         self.assertEquals(list(context['comments']), [comment_2, comment_1])
 
     def test_get_recent_linkbacks(self):
-        user = User.objects.create_user(username='webmaster',
-                                        email='webmaster@example.com')
+        user = User.objects.create_user(username='webmain',
+                                        email='webmain@example.com')
         site = Site.objects.get_current()
         context = get_recent_linkbacks()
         self.assertEquals(len(context['linkbacks']), 0)
@@ -339,9 +339,9 @@ class TemplateTagsTestCase(TestCase):
         context = zinnia_breadcrumbs(source_context)
         self.assertEquals(len(context['breadcrumbs']), 3)
 
-        User.objects.create_user(username='webmaster',
-                                 email='webmaster@example.com')
-        author = Author.objects.get(username='webmaster')
+        User.objects.create_user(username='webmain',
+                                 email='webmain@example.com')
+        author = Author.objects.get(username='webmain')
         source_context = Context({'request': FakeRequest(author.get_absolute_url()),
                                   'object': author})
         context = zinnia_breadcrumbs(source_context)
@@ -364,7 +364,7 @@ class TemplateTagsTestCase(TestCase):
         # More tests can be done here, for testing path and objects in context
 
     def test_get_gravatar(self):
-        self.assertEquals(get_gravatar('webmaster@example.com'),
+        self.assertEquals(get_gravatar('webmain@example.com'),
                           'http://www.gravatar.com/avatar/86d4fd4a22de452a9228298731a0b592.jpg?s=80&amp;r=g')
         self.assertEquals(get_gravatar('  WEBMASTER@example.com  ', 15, 'x', '404'),
                           'http://www.gravatar.com/avatar/86d4fd4a22de452a9228298731a0b592.jpg?s=15&amp;r=x&amp;d=404')


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.